### PR TITLE
Fix integer token in the lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -37,43 +37,44 @@ str_t tok_type_to_str(toktype_t type) { return to_str(toktype_str[type]); }
 
 static int is_ident(char c) { return isalnum(c) || c == '_'; }
 
-static char cur(lexer_state_t* state) {
-    return state->src.content[state->pos];
-}
+static char cur(lexer_state_t *state) { return state->src.content[state->pos]; }
 
-static str_t read_char(lexer_state_t* state) {
+static str_t read_char(lexer_state_t *state) {
     state->pos++;
     return slice_str(state->src, state->pos - 1, state->pos);
 }
 
-static str_t read_integer(lexer_state_t* state) {
+static str_t read_integer(lexer_state_t *state) {
     size_t start = state->pos;
-    while (isdigit(cur(state))) state->pos++;
+    while (isdigit(cur(state)))
+        state->pos++;
 
     return slice_str(state->src, start, state->pos);
 }
 
-static str_t read_identifier(lexer_state_t* state) {
+static str_t read_identifier(lexer_state_t *state) {
     size_t start = state->pos;
-    while (is_ident(cur(state))) state->pos++;
+    while (is_ident(cur(state)))
+        state->pos++;
 
     return slice_str(state->src, start, state->pos);
 }
 
-tok_t lexer_next_tok(lexer_state_t* state) {
-    while (isspace(cur(state))) state->pos++;
+tok_t lexer_next_tok(lexer_state_t *state) {
+    while (isspace(cur(state)))
+        state->pos++;
 
     tok_t tok;
 
     if (state->pos >= state->src.len) {
         tok.type = TOK_EOF;
         tok.literal = to_str("EOF");
-    } else if (is_ident(cur(state))) {
-        tok.type = TOK_IDENTIFIER;
-        tok.literal = read_identifier(state);
     } else if (isdigit(cur(state))) {
         tok.type = TOK_INTEGER;
         tok.literal = read_integer(state);
+    } else if (is_ident(cur(state))) {
+        tok.type = TOK_IDENTIFIER;
+        tok.literal = read_identifier(state);
     } else {
         switch (cur(state)) {
         case ';':

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,8 +1,8 @@
 #ifndef CED_LEXER_H
 #define CED_LEXER_H
 
-#include <stddef.h>
 #include "str.h"
+#include <stddef.h>
 
 typedef enum {
     TOK_ILLEGAL,
@@ -43,7 +43,7 @@ typedef struct {
 } tok_t;
 
 lexer_state_t create_lexer_state(str_t src);
-tok_t lexer_next_tok(lexer_state_t* state);
+tok_t lexer_next_tok(lexer_state_t *state);
 
 str_t tok_type_to_str(toktype_t type);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,9 @@
 #include "lexer.h"
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 str_t read_src(char *path) {
     int fd = open(path, O_RDONLY);
@@ -40,7 +40,8 @@ int main(int argc, char *argv[]) {
         cur = lexer_next_tok(&state);
         str_t type = tok_type_to_str(cur.type);
 
-        printf("%.*s -> %.*s\n", (int)type.len, type.content, (int)cur.literal.len, cur.literal.content);
+        printf("%.*s -> %.*s\n", (int)type.len, type.content,
+               (int)cur.literal.len, cur.literal.content);
     } while (cur.type != TOK_EOF);
 
     return 0;

--- a/src/str.c
+++ b/src/str.c
@@ -1,17 +1,17 @@
 #include "str.h"
 
-str_t to_str(char* null_term_str) {
-	str_t ret;
-	ret.content = null_term_str;
-	ret.len = strlen(null_term_str);
+str_t to_str(char *null_term_str) {
+    str_t ret;
+    ret.content = null_term_str;
+    ret.len = strlen(null_term_str);
 
-	return ret;
+    return ret;
 }
 
 str_t slice_str(str_t str, size_t start, size_t end) {
-	str_t ret;
-	ret.content = str.content + start;
-	ret.len = end - start;
+    str_t ret;
+    ret.content = str.content + start;
+    ret.len = end - start;
 
-	return ret;
+    return ret;
 }

--- a/src/str.h
+++ b/src/str.h
@@ -4,11 +4,11 @@
 #include <string.h>
 
 typedef struct {
-	char* content;
-	size_t len;
+    char *content;
+    size_t len;
 } str_t;
 
-str_t to_str(char* null_term_str);
+str_t to_str(char *null_term_str);
 str_t slice_str(str_t str, size_t start, size_t end);
 
 #endif


### PR DESCRIPTION
- Integers take precedence over identifiers (because identifiers cannot start with a digit). Before this pull request, digits were detected as identifiers.
- clang-format.